### PR TITLE
Uitbreiden specificatie gedrag Applicaties

### DIFF
--- a/sections/03-specificaties/01-protocollen.md
+++ b/sections/03-specificaties/01-protocollen.md
@@ -6,4 +6,5 @@ Het is ***AANBEVOLEN*** om het OpenTelemetry Protocol (OTLP) te gebruiken in de 
 
 > OpenTelemetry is een open source framework voor het beheren, genereren, verzamelen en exporteren van telemetriegegevens. Door het gebruik van deze open standaard kunnen leverancierspecifieke integraties voorkomen worden.
 
-Als gebruik wordt gemaakt van  HTTP/1.1 [[RFC9112]] of HTTP/2 [[RFC9113]] voor het uitvoeren van dataverwerkingen in meerdere applicaties ***MOET*** gebruik worden gemaakt van de Trace Context specificatie voor het uitwisselen van context informatie.
+Als gebruik wordt gemaakt van  HTTP/1.1 [[RFC9112]] of HTTP/2 [[RFC9113]] voor het uitvoeren van dataverwerkingen in meerdere applicaties ***MOET*** gebruik worden gemaakt van de W3C Trace Context specificatie voor het uitwisselen van metagegevens over {{Traces}}.
+

--- a/sections/03-specificaties/02-component-logboek.md
+++ b/sections/03-specificaties/02-component-logboek.md
@@ -1,6 +1,6 @@
 # Component: Logboek
 
-Voor ieder Logboek waarin dataverwerkingen worden gelogd gelden de volgende specificaties voor gedrag en interface.
+Voor ieder Logboek waarin Dataverwerkingen worden gelogd gelden de volgende specificaties voor gedrag en interface.
 
 
 ## Gedrag
@@ -47,4 +47,5 @@ Het veld `resource` is een bericht, opgebouwd uit het volgende veld:
 Het veld `attributes` is een lijst van *key-value pairs*, in een namespace met prefix `dpl.` (data processing log). De volgende attributen zijn mogelijk in de namespace `core`:
 
 - `dpl.core.processing_activity_id`: URI; Verwijzing naar register met meer informatie over de verwerkingsactiviteit
-- `dpl.core.data_subject_id`: ID van de Betrokkene; versleuteld. Dit is bijvoorbeeld een `BSN` of `Vreemdelingennummer` waarmee wordt aangeduid welke persoon Betrokkene is bij de verwerking, gelet op de AVG.
+- `dpl.core.data_subject_id`: ID van de Betrokkene; versleuteld. Hiermee wordt aangeduid welke persoon Betrokkene is bij de verwerking, gelet op de AVG.
+- `dpl.core.data_subject_id_type`: Type van het veld `data_subject_id`. Dit is bijvoorbeeld `BSN`, `Personeelsnummer` of `Vreemdelingennummer`, of een URI naar een Register waar het veld precies wordt geduid.

--- a/sections/03-specificaties/03-component-applicatie.md
+++ b/sections/03-specificaties/03-component-applicatie.md
@@ -1,21 +1,44 @@
 # Component: Applicatie
 
-Voor iedere applicatie waarin dataverwerkingen plaatsvinden die gelogd moeten worden gelden de volgende specificaties voor het gedrag.
+Voor iedere Applicatie waarin Dataverwerkingen plaatsvinden gelden de volgende specificaties voor gedrag.
 
 
 ## Gedrag
 
-De applicatie ***MOET*** een Trace starten voor iedere Dataverwerking waarvan nog geen Trace bekend is.
+Het gesprecificeerde gedrag van Applicaties is erop gericht om de interface van het Logboek te gebruiken. Voor alle metadata geldt dat de specificatie te vinden is in de interface van het Logboek.
 
-De applicatie ***MOET*** voor iedere Dataverwerking een logregel wegschrijven in een Logboek. *Log Sampling* is niet toegestaan.
+De Applicatie ***MOET*** een nieuwe Trace  met een uniek `trace_id` starten voor iedere nieuwe Dataverwerking. In een Trace wordt de metadata bijgehouden die nodig is om de interface van een Logboek te gebruiken.
 
-De applicatie ***MOET*** bijhouden of een Dataverwerking geslaagd of mislukt is en dit per Dataverwerking als status meegeven aan het Logboek.
+Een Dataverwerking kan uit meerdere activiteiten bestaan. De applicatie ***MOET*** een voor iedere nieuwe activiteit een unieke `operation_id` bijhouden. Iedere Trace heeft tenminste één `operation_id`.
+
+Wanneer een activiteit binnen een Applicatie is gestart door een andere activiteit, dan ***MOET*** de Applicatie de `trace_id` ongewijzigd overnemen en de `operation_id` opnemen in een veld genaamd `parent_operation_id` voor deze nieuwe activiteit.
 
 Als een Dataverwerking meerdere Betrokkenen heeft dan ***MOET*** de applicatie voor iedere Betrokkene een aparte logregel wegschrijven. Een logregel kan naar 0 of 1 Betrokkenen verwijzen.
 
-Als een applicatie aangeroepen kan worden vanuit een andere applicatie ***MOET*** de applicatie Trace Context metadata accepteren bij een dergelijke aanroepen deze metadata kunnen omzetten naar een `foreign_operation` bericht.
+De Applicatie ***MOET*** voor iedere activiteit (`operation_id`) een logregel wegschrijven via de interface van het Logboek.
+
+De Applicatie ***MOET*** bijhouden of een activiteit geslaagd of mislukt is en dit per Dataverwerking als status (`status_code`) meegeven in de Logregel.
+
+Als de Applicatie een verzoek van een andere Applicatie kan ontvangen, ***MOET*** de Applicatie metagegevens volgens de W3C Trace Context standaard kunnen verwerken en gebruiken in de eigen Trace(s). Metadata verkregen via W3C Trace Context ***MOET*** als `foreign_operation` worden opgenomen in de Logregel.
+
+Als de Applicatie een verzoek aan een andere Applicatie kan versturen, ***MOET*** de Applicatie metagegevens volgens de W3C Trace Context standaard meegeven aan dit verzoek.
+
+De Applicatie ***MAG NIET*** gebruik maken van *Log Sampling*.
 
 
-## Interface
+### Loggen van Dataverwerkingen met persoonsgegevens
 
-De Applicatie heeft geen voor deze standaard relevante interface. Voor het uitwisselen van de <a>Trace</a> wordt W3C Trace Context gebruikt.
+Voor iedere Betrokkene moet iedere Dataverwerking apart gelogd worden. De Applicatie ***MOET*** in elke Logregel een identificerende code van de Betrokkene opnemen in `dpl.core.data_subject_id` en aan te duiden welk soort identificerende code wordt gebruikt in `dpl.core.data_subject_id_type`. Het wordt ***AANBEVOLEN*** om de identificerende code te pseudonimiseren.
+
+Wanneer een enkele Dataverwerking meerdere Betrokkenen heeft, ***MOET*** de Applicatie voor elke Betrokkene een nieuwe activiteit met unieke `operation_id` starten en deze onder de reeds bekende activiteit voegen door het `operation_id` daarvan op te nemen als `parent_operation_id` in de nieuwe activiteit. Voor iedere betrokkene wordt een *child operation* bijgehouden.
+
+Let op: het kan zijn dat pas na een antwoord van een externe Applicatie bekend is dat er meerdere Betrokkenen zijn bij een Dataverwerking, in dat geval moeten na ontvangst van het antwoord de nieuwe activiteiten ten behoeve van correcte logging gestart worden.
+
+Iedere Dataverwerking van persoonsgegevens betreft een Verwerkingsactiviteit die in het Register van Verwerkingsactiviteiten moet zijn opgenomen. De Applicatie ***MOET*** in de Logregel een verwijzing naar de juiste Verwerkingsactiviteit in het Register van Verwerkingsactiviteiten opnemen in het veld `dpl.core.processing_activity_id`.
+
+
+### Loggen van Dataverwerkingen zonder persoonsgegevens
+
+Dataverwerkingen zonder persoonsgegevens zijn over het algemeen niet als Verwerkingsactiviteit opgenomen in het Register van Verwerkingsactiviteiten. Het wordt aanbevolen om wel een soortgelijk register bij te houden voor alle Dataverwerkingen zonder persoonsgegevens.
+
+Het wordt ***AANBEVOLEN*** dat de Applicatie in de Logregel een verwijzing naar de juiste Verwerkingsactiviteit in een daarvoor aan te wijzen Register opneemt in het veld `dpl.core.processing_activity_id`.

--- a/sections/03-specificaties/04-component-register.md
+++ b/sections/03-specificaties/04-component-register.md
@@ -1,6 +1,6 @@
 # Component: Register
 
-Voor ieder register met statische gegevens over dataverwerkingen die gelogd moeten worden gelden de volgende specificaties voor het gedrag en de interface.
+Voor ieder register met statische gegevens over Dataverwerkingen die gelogd moeten worden gelden de volgende specificaties voor het gedrag en de interface.
 
 
 ## Gedrag


### PR DESCRIPTION
Op basis praktijktesten verduidelijkingen aangebracht in de specificatie van het gedrag van Applicaties.
Met name het omgaan met meerdere Betrokkenen en de situatie waarbij Betrokkenen pas bekend zijn uit het antwoord.
Ook een onderscheid gemaakt in het loggen met en zonder persoonsgegevens.