### PR TITLE
Fix links die missen

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,10 @@ const localConfig = {
   publishVersion: "0.8.0",
   github: "https://github.com/Logius-standaarden/logboek-dataverwerkingen",
 
+  // TODO: Voordat we releasen moet dit weg worden gehaald. Op dit moment is er nog
+  // geen publicatie van deze standaard.
+  latestVersion: "",
+
   license: "cc-by",
   specStatus: "wv",
   specType: "st",

--- a/sections/01-introductie/01-doel.md
+++ b/sections/01-introductie/01-doel.md
@@ -19,4 +19,4 @@ Organisatorisch werkingsgebied: Nederlandse overheden (Rijk, provincies, gemeent
 
 ## Doelgroep
 
-De standaard heeft als doelgroep iedereen die zich bezighoudt met het implementeren van logging rond dataverwerkingen en beschrijft alleen wat relevant is voor de implementatie. Alle achterliggende overwegingen zijn te vinden in de [Algemene inleiding](https://logius-standaarden.github.io/publicatie/api/Logboek_Algemeen/) en het [Juridisch Beleidskader](https://logius-standaarden.github.io/publicatie/api/Logboek_Juridisch/).
+De standaard heeft als doelgroep iedereen die zich bezighoudt met het implementeren van logging rond dataverwerkingen en beschrijft alleen wat relevant is voor de implementatie. Alle achterliggende overwegingen zijn te vinden in de [Algemene inleiding](https://logius-standaarden.github.io/logboek-dataverwerkingen_Inleiding/) en het [Juridisch Beleidskader](https://logius-standaarden.github.io/logboek-dataverwerkingen_Juridisch-beleidskader/).


### PR DESCRIPTION
Op dit moment faalt de link check omdat er enkele links
zijn die niet bestaan. Hiermee fixen we de link checks door
de correct URLs te gebruiken en de laatst gepubliceerde
versie te negeren.