### PR TITLE
Verwijder referentie naar persoon in inzage

### DIFF
--- a/sections/01-introductie/00-introductie.md
+++ b/sections/01-introductie/00-introductie.md
@@ -1,2 +1,1 @@
-<!-- markdownlint-disable first-line-heading -->
-Deze sectie geeft een introductie op de standaard. Sectie 2 beschrijft de architectuur van systemen die de standaard gebruiken. Sectie 3 beschrijft de interfaces en het gedrag van componenten die de standaard volgen in detail.
+

--- a/sections/01-introductie/02-terminologie.md
+++ b/sections/01-introductie/02-terminologie.md
@@ -24,7 +24,7 @@ Iedere bewerking (of ieder geheel van bewerkingen) met betrekking tot gegevens, 
 
 <dfn>Inzage</dfn>
 
-De Betrokkene heeft het recht om van de {{Verantwoordelijke}} uitsluitsel te verkrijgen over het al dan niet verwerken van hem betreffende persoonsdata en, wanneer dat het geval is, om inzage te verkrijgen van die persoonsdata ([[AVG]], art. 15, lid 1). Met *Inzage* doelen we op de handeling waarmee uitvoering wordt gegeven aan dat recht.
+De Betrokkene heeft het recht om van de {{Verantwoordelijke}} uitsluitsel te verkrijgen over het al dan niet verwerken van hem betreffende gegevens en, wanneer dat het geval is, om inzage te verkrijgen van die gegevens ([[AVG]], art. 15, lid 1). Met *Inzage* doelen we op de handeling waarmee uitvoering wordt gegeven aan dat recht.
 
 <dfn data-lt="Logboeken">Logboek</dfn>
 


### PR DESCRIPTION
Hiermee halen we de limitatie weg dat het alleen over personen gaat.
Met de potentiele toevoeging van niet-natuurlijke rechtspersonen
voor betrokkene is daar de categorie van gegevens gedefinieerd.

Fixes #41
Relates to #38
Relates to #100