### PR TITLE
Verwijder referentie naar AVG in Register definitie

### DIFF
--- a/sections/01-introductie/02-terminologie.md
+++ b/sections/01-introductie/02-terminologie.md
@@ -37,7 +37,7 @@ Resultaat van een enkele gebeurtenis in de logging [NEN7513: Medische informatic
 
 <dfn data-lt="Registers">Register</dfn>
 
-Register waarin statische data over {{Verwerkingsactiviteiten}} worden geregistreerd en ter beschikking gesteld, zoals het Register van {{Verwerkingsactiviteiten}} uit [[AVG]] art. 30.
+Register waarin statische data over {{Verwerkingsactiviteiten}} worden geregistreerd en ter beschikking gesteld.
 
 
 <dfn data-lt="Traces">Trace</dfn>

--- a/sections/02-architectuur/02-componenten.md
+++ b/sections/02-architectuur/02-componenten.md
@@ -24,3 +24,9 @@ Het Register kan een Applicatie zijn, in dat geval is het een Applicatie met een
 Dataverwerkingen in het Register worden gelogd in een Logboek Dataverwerkingen.
 
 Voor alle Dataverwerkingen waarbij persoonsdata worden verwerkt is wettelijk geregeld dat de Verwerkingsactiviteiten moeten worden beschreven in het zogenaamde Register van Verwerkingsactiviteiten (AVG art. 30). Dit Register wordt verondersteld aanwezig te zijn in iedere organisatie die de standaard Logboek Dataverwerkingen toepast.
+
+Verwerkingsactiviteiten waarin geen persoonsdata worden verwerkt staan niet verplicht in het Register van Verwerkingsactiviteiten. De standaard laat ruimte om dit op te lossen naar eigen voorkeur:
+* In het bestaande Register ook Verwerkingsactiviteiten opnemen zonder persoonsdata, al is dit niet wettelijk verplicht
+* Zelf een ander Register opzetten met gelijke interface maar specifiek voor Verwerkingsactiviteiten zonder persoonsdata
+
+Het is daarnaast ook mogelijk om Registers te gebruiken met heel andere statische informatie die meer context geeft over een Logregel, bijv. informatie over de gebruikte beslisregels of van toepassing zijnde normen. Dit wordt niet verder uitgewerkt.


### PR DESCRIPTION
In plaats daarvan beschrijven we bij componenten de opties en laten we expliciet
ruimte voor de implementatie.

Fixes #91