### PR TITLE
Beheer: polishing in terminologie sectie

### DIFF
--- a/sections/01-introductie/02-terminologie.md
+++ b/sections/01-introductie/02-terminologie.md
@@ -6,25 +6,21 @@ De volgende lijst beschrijft terminologie in de betekenis zoals deze wordt gebru
 
 Een {{Dataverwerking}} bestaat uit één of meerdere kleinere discrete stappen. Een Actie is één discrete stap binnen een Dataverwerking.
 
-
 <dfn data-lt="Applicaties">Applicatie</dfn>
 
-Iedere softwaretoepassing waarmee dataverwerkingen worden uitgevoerd.
+Iedere softwaretoepassing waarmee {{Dataverwerkingen}} worden uitgevoerd.
 
+<dfn data-lt="Betrokkenen">Betrokkene</dfn>
 
-<dfn data-lt="Betrokkenen|Betrokkene">Betrokkene</dfn>
+Als persoonsdata worden verwerkt, wordt de persoon van wie de organisatie persoonsdata verwerkt de 'Betrokkene' genoemd. Dat is dus degene over wie de {{Dataverwerking}} gaat. De Betrokkene is degene op wie een persoonsgegeven betrekking heeft en die daarmee geïdentificeerd kan worden. Als identificeerbaar wordt beschouwd een natuurlijke persoon die direct of indirect kan worden geïdentificeerd, met name aan de hand van een identificator zoals een naam, een identificatienummer, locatiedata, een online identificator of van een of meer elementen die kenmerkend zijn voor de fysieke, fysiologische, genetische, psychische, economische, culturele of sociale identiteit van die natuurlijke persoon ([NORA: De Privacy Baseline/Persoonsgegevens en bijzondere persoonsgegevens](https://www.noraonline.nl/wiki/De_Privacy_Baseline/Persoonsgegevens_en_bijzondere_persoonsgegevens)).
 
-Als persoonsdata worden verwerkt, wordt de persoon van wie de organisatie persoonsdata verwerkt de 'Betrokkene' genoemd. Dat is dus degene over wie de dataverwerking gaat. De Betrokkene is degene op wie een persoonsgegeven betrekking heeft en die daarmee geïdentificeerd kan worden. Als identificeerbaar wordt beschouwd een natuurlijke persoon die direct of indirect kan worden geïdentificeerd, met name aan de hand van een identificator zoals een naam, een identificatienummer, locatiedata, een online identificator of van een of meer elementen die kenmerkend zijn voor de fysieke, fysiologische, genetische, psychische, economische, culturele of sociale identiteit van die natuurlijke persoon [NORA: De Privacy Baseline/Persoonsgegevens en bijzondere persoonsgegevens]
-
-
-<dfn data-lt="Dataverwerkingen|Dataverwerking">Dataverwerking</dfn>
+<dfn data-lt="Dataverwerkingen">Dataverwerking</dfn>
 
 Iedere bewerking (of ieder geheel van bewerkingen) met betrekking tot gegevens, al dan niet uitgevoerd via geautomatiseerde procedures, zoals het verzamelen, vastleggen, ordenen, structureren, opslaan, bijwerken of wijzigen, opvragen, raadplegen, gebruiken, verstrekken door middel van doorzending, verspreiden of op andere wijze ter beschikking stellen, aligneren of combineren, afschermen, wissen of vernietigen van gegevens wordt opgevat als een Dataverwerking. Iedere Dataverwerking bestaat uit één of meerdere {{Acties}}. Voor verwerking van persoonsdata sluit dit aan bij de Algemene Verordening Gegevensbescherming (art. 4 lid 2).
 
-
 <dfn>Inzage</dfn>
 
-De Betrokkene heeft het recht om van de {{Verantwoordelijke}} uitsluitsel te verkrijgen over het al dan niet verwerken van hem betreffende gegevens en, wanneer dat het geval is, om inzage te verkrijgen van die gegevens ([[AVG]], art. 15, lid 1). Met *Inzage* doelen we op de handeling waarmee uitvoering wordt gegeven aan dat recht.
+De {{Betrokkene}} heeft het recht om van de {{Verantwoordelijke}} uitsluitsel te verkrijgen over het al dan niet verwerken van hem betreffende gegevens en, wanneer dat het geval is, om inzage te verkrijgen van die gegevens ([[AVG]], art. 15, lid 1). Met *Inzage* doelen we op de handeling waarmee uitvoering wordt gegeven aan dat recht.
 
 <dfn data-lt="Logboeken">Logboek</dfn>
 
@@ -32,31 +28,26 @@ Softwaretoepassing waarmee het log van {{Dataverwerkingen}} wordt bijgehouden.
 
 <dfn>Logregel</dfn>
 
-Resultaat van een enkele gebeurtenis in de logging [NEN7513: Medische informatica - logging - vastleggen van acties op persoonlijke gezondheidsinformatie](https://www.nen.nl/nen-7513-2024-nl-329182).
-
+Resultaat van een enkele gebeurtenis in de logging.
 
 <dfn data-lt="Registers">Register</dfn>
 
 Register waarin statische data over {{Verwerkingsactiviteiten}} worden geregistreerd en ter beschikking gesteld.
 
-
 <dfn data-lt="Traces">Trace</dfn>
 
 Concept waarmee bij elkaar behorende {{Dataverwerkingen}} binnen de grenzen van een systeem worden gegroepeerd.
 
-
 <dfn data-lt="Verantwoordelijke|Verantwoordelijken|Verwerkingsverantwoordelijken">Verwerkingsverantwoordelijke</dfn>
 
- Een natuurlijke persoon of rechtspersoon, een overheidsinstantie, een dienst of een ander orgaan die/dat, alleen of samen met anderen, het doel van en de middelen voor de verwerking van data vaststelt. Deze definitie is gebaseerd op ([[AVG]] art. 4, lid 7.), maar laat de verantwoordelijkheid betrekking hebben op de verwerking van álle data, niet alleen persoonsdata.
+Een natuurlijke persoon of rechtspersoon, een overheidsinstantie, een dienst of een ander orgaan die/dat, alleen of samen met anderen, het doel van en de middelen voor de verwerking van data vaststelt. Deze definitie is gebaseerd op ([[AVG]] art. 4, lid 7.), maar laat de verantwoordelijkheid betrekking hebben op de verwerking van álle data, niet alleen persoonsdata.
 
- | In de standaard wordt de Verwerkingsverantwoordelijke aangeduid als de Verantwoordelijke voor de leesbaarheid.
-
+<p class="note">In de standaard wordt de Verwerkingsverantwoordelijke aangeduid als de Verantwoordelijke voor de leesbaarheid.
 
 <dfn data-lt="Verwerkers">Verwerker</dfn>
 
- Een natuurlijke persoon of rechtspersoon, een overheidsinstantie, een dienst of een ander orgaan die/dat ten behoeve van de {{Verwerkingsverantwoordelijke}} persoonsdata verwerkt. Deze definitie is gebaseerd op ([[AVG]] art. 4, lid 8.), maar laat de verantwoordelijkheid betrekking hebben op de verwerking van álle data, niet alleen persoonsdata.
-
+Een natuurlijke persoon of rechtspersoon, een overheidsinstantie, een dienst of een ander orgaan die/dat ten behoeve van de {{Verwerkingsverantwoordelijke}} persoonsdata verwerkt. Deze definitie is gebaseerd op ([[AVG]] art. 4, lid 8.), maar laat de verantwoordelijkheid betrekking hebben op de verwerking van álle data, niet alleen persoonsdata.
 
 <dfn data-lt="Verwerkingsactiviteiten">Verwerkingsactiviteit</dfn>
 
-{{Verwerkingsactiviteiten}} zijn de activiteiten die een organisatie onderkent heeft als activiteiten waarbinnen {{Dataverwerkingen}} plaatsvinden.
+Activiteiten die een organisatie onderkent heeft als activiteiten waarbinnen {{Dataverwerkingen}} plaatsvinden.


### PR DESCRIPTION
- opruimen van links die misten
- extra spaties aan het begin van een zin
- note nu ook als note markeren
- definities opruimen (hoeft niet duplicate)

Fixes #119