### PR TITLE
Beheer: fix het genereren van PDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <script src="https://gitdocumentatie.logius.nl/publicatie/respec/builds/respec-nlgov.js" class="remove" async></script>
   <script src="https://gitdocumentatie.logius.nl/publicatie/respec/organisation-config.js" class="remove"></script>
   <script src="js/config.js" class="remove"></script>
+  <script class="remove"> respecConfig = {...organisationConfig, ...respecConfig}</script>
 </head>
 <body>
   <section id="abstract" data-include="sections/00-abstract/00-abstract.md" data-include-format="markdown"></section>

--- a/js/config.js
+++ b/js/config.js
@@ -1,4 +1,4 @@
-const localConfig = {
+var localConfig = {
   maxTocLevel: 3,
   specStatus: "WV",
   specType: "ST",
@@ -61,5 +61,3 @@ const localConfig = {
     },
   ],
 };
-
-const respecConfig = {...organisationConfig, ...localConfig}


### PR DESCRIPTION
Voor PDF's mag de `organisatieconfig` niet in het bestandje staan
maar moet dat in de `index.html` zelf.