### PR TITLE
Verplaats `foreign_operation` naar `attributes`

### DIFF
--- a/sections/03-specificaties/02-component-logboek.md
+++ b/sections/03-specificaties/02-component-logboek.md
@@ -15,15 +15,14 @@ De interface ***MOET*** de volgende velden implementeren:
 | Veld                  | Type           | optioneel | Omschrijving |
 |-----------------------|----------------|---------------|--------------|
 | `trace_id`            | 16 byte        | verplicht     | Unieke identificerende code van {{Trace}} die {{Dataverwerking}} volgt |
-| `span_id`        |  8 byte        | verplicht     | Unieke identificerende code van {{Actie}} binnen de Dataverwerking |
+| `span_id`             |  8 byte        | verplicht     | Unieke identificerende code van {{Actie}} binnen de Dataverwerking |
 | `status_code`         | enum           | verplicht     | Status van de Actie |
 | `name`                | string         | verplicht     | Naam van de specifieke Actie binnen de Dataverwerking |
 | `start_time`          | timestamp (ms) | verplicht     | Tijdstip waarop de Actie gestart is |
 | `end_time`            | timestamp (ms) | verplicht     | Tijdstip waarop de Actie beëindigd is |
-| `parent_span_id` |  8 byte        | optioneel     | Unieke identificerende code aanroepende Actie *binnen huidige Trace* |
-| `foreign_operation`   | message        | optioneel     | Unieke identificerende code aanroepende Actie *bij externe partij* |
-| `resource`            | message        | optioneel     | Zie toelichting hieronder |
-| `attributes`          | list           | verplicht     | Verplichte key-value pairs |
+| `parent_span_id`      |  8 byte        | optioneel     | Unieke identificerende code aanroepende Actie *binnen huidige Trace* |
+| `resource`            | object         | optioneel     | Zie toelichting hieronder |
+| `attributes`          | object         | verplicht     | Zie toelichting hieronder |
 
 Het veld `span_id` is in implementaties voor logging.
 
@@ -34,16 +33,6 @@ Het veld `status_code` is een enumeratie die de volgende waarden kan bevatten:
 * `2: STATUS_CODE_ERROR`: De waarde `Error` wordt toegekend bij fouten die zijn ontstaan binnen het systeem dat de dataverwerking uitvoert, zoals interne fouten of mislukte uitvoeringen door technische oorzaken.
 
 De waarden `Unset` en `Ok` worden altijd bepaald op basis van het resultaat van de verwerking. De waarde `Ok` is optioneel en kan gebruikt worden als de organisatie ervoor kiest dataverwerkingen expliciet als succesvol te markeren. `Error` is alleen nodig als er een fout is opgetreden bij het interne proces. Een dataverwerking die niet klopt op basis van de gegeven gebruikersinput, maar die zonder fouten is afgehandeld, hoort dus status `Unset` te krijgen.
-
-Het veld `foreign_operation` is een `message`, opgebouwd uit de volgende velden:
-
-| Veld                  | Type           | optioneel | Omschrijving |
-|-----------------------|----------------|---------------|--------------|
-| `trace_id`            | 16 byte        | verplicht     | Unieke identificerende code van *Trace* bij externe partij |
-| `span_id`        |  8 byte        | verplicht     | Unieke identificerende code van de *Actie* bij externe partij |
-| `entity`              |  URI           | verplicht     | URI verwijzend naar externe partij |
-
-Deze velden worden optioneel aangeboden door een aanroepende Applicatie, zie de specificatie van het [gedrag van Applicaties](#gedrag).
 
 Het veld `resource` is een object, opgebouwd uit de volgende velden:
 
@@ -56,8 +45,24 @@ Het veld `attributes` is een object, opgebouwd uit velden in een namespace met p
 | Veldnaam                        | Type   | Omschrijving |
 |---------------------------------|--------|--------------|
 | dpl.core.processing_activity_id | URI    | Verwijzing naar een Register met meer informatie over de Verwerkingsactiviteit. |
-| dpl.core.data_subject_id        | String    | Unieke, versleutelde identificerende code van de Betrokkene. |
+| dpl.core.data_subject_id        | String | Unieke, versleutelde identificerende code van de Betrokkene. |
 | dpl.core.data_subject_id_type   | String | Type van de identificerende code, zoals BSN, personeelsnummer, of een URI naar een Register dat het type specificeert. |
+
+De volgende velden in de namespace `core` zijn enkel vereist als er een aanroepende Applicatie is, zie de specificatie van het [gedrag van Applicaties](#gedrag).
+
+| Veldnaam                             | Type    | Omschrijving |
+|--------------------------------------|---------|--------------|
+| dpl.core.foreign_operation.trace_id  | 16 byte | Unieke identificerende code van *Trace* bij externe partij |
+| dpl.core.foreign_operation.span_id   |  8 byte | Unieke identificerende code van de *Actie* bij externe partij |
+| dpl.core.foreign_operation.processor | URL     | Link naar website van externe partij. Op deze website moet het bestand `<URL>/.well-known/privacy.text` gepubliceerd zijn |
+
+Om traces te kunnen relateren aan elkaar is de URL een locator link naar de externe partij. Om vervolgens contactgegevens van deze externe partij op te halen, MOET `<URL>/.well-known/privacy.text` beschikbaar zijn en hier bijvoorbeeld een emailadres of telefoonnummer in staan.
+
+<aside class="example">
+
+Als een gemeente een applicatie van de RDW aanroept, moet de RDW `dpl.core.foreign_operation.processor` zetten op <code>https://gemeente.nl</code>. Vervolgens moet <code>https://gemeente.nl/.well-known/privacy.txt</code> resulteren in een tekst bestand waar contactgegevens instaan van de verwerkingsverantwoordelijke van de gemeente.
+
+</aside>
 
 <div class="note">
 


### PR DESCRIPTION
Tevens hernoemen we `entity` naar `processor` en is het een type
een URL. Op deze URL moet een `/.well-known/privacy.txt`
beschikbaar zijn waar contactgegevens van de
verwerkingsverantwoordelijke in staan.

Fixes #149