### PR TITLE
Maak kleine verandering in `index.html` om cache te busten

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta content="text/html; charset=utf-8" http-equiv="content-type">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="color-scheme" content="light dark">
+  <meta name="color-scheme" content="dark light">
   <link rel="shortcut icon" type="image/x-icon" href="https://gitdocumentatie.logius.nl/publicatie/respec/style/logos/logius.ico" />
   <title>Logboek dataverwerkingen</title>
   <script src="https://gitdocumentatie.logius.nl/publicatie/respec/builds/respec-nlgov.js" class="remove" async></script>


### PR DESCRIPTION
Bij de vorige build is er iets fout gegaan bij GitHub waardoor de cache key niet goed word aangemaakt. Dit zorgt ervoor dat de werkversie leeg is en niet meer gebouwd kan worden.

We kunnen 24 uur wachten, maar dat is wel erg lang. Daarom maken we deze wijziging die geen invloed heeft, maar wel een andere cache zal opleveren.