### PR TITLE
Beheer: Align status_code met OpenTelemetry SDK (normatief document)

### DIFF
--- a/sections/03-specificaties/02-component-logboek.md
+++ b/sections/03-specificaties/02-component-logboek.md
@@ -32,11 +32,11 @@ Het veld `span_id` is in implementaties voor logging.
 
 Het veld `status_code` is een enumeratie die de volgende waarden kan bevatten:
 
-* `0: STATUS_CODE_UNSET`: De standaardwaarde voor elke `status_code` is `Unset`. Dit betekent dat de dataverwerking is uitgevoerd zonder interne fout. Deze waarde wordt toegepast wanneer de dataverwerking technisch correct is afgerond, ook als er geen resultaat beschikbaar is of wanneer de invoer onvolledig was.
-* `1: STATUS_CODE_OK`: De waarde `Ok` kan optioneel gebruikt worden wanneer de ontwikkelaar expliciet wil markeren dat de dataverwerking succesvol is afgerond. Dit is afhankelijk van hoe de organisatie die de standaard implementeert een dataverwerking als succesvol definieert en of zij dit onderscheid expliciet willen loggen als andere waarde dan `Unset`.
-* `2: STATUS_CODE_ERROR`: De waarde `Error` wordt toegekend bij fouten die zijn ontstaan binnen het systeem dat de dataverwerking uitvoert, zoals interne fouten of mislukte uitvoeringen door technische oorzaken.
+* `STATUS_CODE_UNSET`: De standaardwaarde voor elke `status_code` is `STATUS_CODE_UNSET`. Dit betekent dat de dataverwerking is uitgevoerd zonder interne fout. Deze waarde wordt toegepast wanneer de dataverwerking technisch correct is afgerond, ook als er geen resultaat beschikbaar is of wanneer de invoer onvolledig was.
+* `STATUS_CODE_OK`: De waarde `STATUS_CODE_OK` kan optioneel gebruikt worden wanneer de ontwikkelaar expliciet wil markeren dat de dataverwerking succesvol is afgerond. Dit is afhankelijk van hoe de organisatie die de standaard implementeert een dataverwerking als succesvol definieert en of zij dit onderscheid expliciet willen loggen als andere waarde dan `STATUS_CODE_UNSET`.
+* `STATUS_CODE_ERROR`: De waarde `STATUS_CODE_ERROR` wordt toegekend bij fouten die zijn ontstaan binnen het systeem dat de dataverwerking uitvoert, zoals interne fouten of mislukte uitvoeringen door technische oorzaken.
 
-De waarden `Unset` en `Ok` worden altijd bepaald op basis van het resultaat van de verwerking. De waarde `Ok` is optioneel en kan gebruikt worden als de organisatie ervoor kiest dataverwerkingen expliciet als succesvol te markeren. `Error` is alleen nodig als er een fout is opgetreden bij het interne proces. Een dataverwerking die niet klopt op basis van de gegeven gebruikersinput, maar die zonder fouten is afgehandeld, hoort dus status `Unset` te krijgen.
+De waarden `STATUS_CODE_UNSET` en `STATUS_CODE_OK` worden altijd bepaald op basis van het resultaat van de verwerking. De waarde `STATUS_CODE_OK` is optioneel en kan gebruikt worden als de organisatie ervoor kiest dataverwerkingen expliciet als succesvol te markeren. `STATUS_CODE_ERROR` is alleen nodig als er een fout is opgetreden bij het interne proces. Een dataverwerking die niet klopt op basis van de gegeven gebruikersinput, maar die zonder fouten is afgehandeld, hoort dus status `STATUS_CODE_UNSET` te krijgen.
 
 ### `resource`
 


### PR DESCRIPTION
Zie issue #206, uit de gebruikersvraag kan geconcludeerd worden dat de beschrijving de sectie Status_Code niet duidelijk genoeg is en onze documentatie meerdere varianten bevat en dit verwarrend over kan komen bij implementatie. Er is gekeken naar hoe de [huidige referentie implementatie](https://gitlab.com/digilab.overheid.nl/ecosystem/logboek-dataverwerkingen/ldv-referentie-implementatie/-/blob/main/apps/rijksoverheid/mijnoverheid/frontend/src/lib/ldv-inzicht-api-client/types.gen.ts#L30) dit regelt en dit is conform de OpenTelemetry SDK geschreven. Het is de bedoeling om onze enumeratiewaarden ook conform de SDK te houden.