### PR TITLE
Beheer: negeer line ending changes in `.xlsx`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*.xlsx binary


### PR DESCRIPTION
Anders gaat het fout bij een niet-Windows checkout van deze repository die probeert om een `.xlsx` met LF line endings op te slaan.